### PR TITLE
Image placeholder - Loading & 404

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "camelcase": "off",
     "curly": "warn",
     "nonblock-statement-body-position": "off",
-    "no-restricted-globals": "off"
+    "no-restricted-globals": "off",
+    "quotes": ["error", "single"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^16.8.5",
     "react-animate-on-change": "^2.1.1",
     "react-dom": "^16.8.5",
+    "react-image": "^2.1.1",
     "react-select": "^2.4.2",
     "react-spinkit": "^3.0.0"
   },

--- a/src/client/Directory/StreamCell.css
+++ b/src/client/Directory/StreamCell.css
@@ -5,14 +5,24 @@
     "gameThumb basicDetails"
     "gameName gameName"
     "streamTitle streamTitle";
-  grid-template-rows: fit-content(300px) 45px fit-content(300px) fit-content(
-      300px
-    );
+  grid-template-rows:
+    fit-content(300px)
+    45px
+    fit-content(300px)
+    fit-content(300px);
   grid-template-columns: 30px 1fr;
   grid-column-gap: 8px;
 }
 .streamThumbnail {
   grid-area: streamThumb;
+
+  /* Automatically fill space where the stream image belongs, to reduce jumpiness on load */
+  width: 100%;
+  height: 0;
+  padding-top: 57.6%;
+  position: relative;
+  background-color: var(--light);
+  margin-bottom: 2%;
 }
 .gameThumbAndLink {
   grid-area: gameThumb;
@@ -28,6 +38,9 @@
   grid-area: streamTitle;
 }
 .streamThumbnail img {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
 }
 .gameThumbnail {

--- a/src/client/Directory/StreamCell.js
+++ b/src/client/Directory/StreamCell.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { Component } from "react";
 // import './Directory.css';
-import './StreamCell.css';
-import PropTypes from 'prop-types';
+import "./StreamCell.css";
+import PropTypes from "prop-types";
 
 const StreamWidth = 230;
 const StreamAspectRatio = 1.75;
@@ -20,7 +20,7 @@ export default class StreamCell extends Component {
 
   getStreamThumbnail(name) {
     return this.getThumbnail(
-      'https://static-cdn.jtvnw.net/previews-ttv/live_user_',
+      "https://static-cdn.jtvnw.net/previews-ttv/live_user_",
       name,
       StreamWidth,
       StreamAspectRatio
@@ -29,7 +29,7 @@ export default class StreamCell extends Component {
 
   getGameThumbnail(game) {
     return this.getThumbnail(
-      'https://static-cdn.jtvnw.net/ttv-boxart/',
+      "https://static-cdn.jtvnw.net/ttv-boxart/",
       game,
       GameWidth,
       GameAspectRatio
@@ -43,7 +43,10 @@ export default class StreamCell extends Component {
       <div className="streamCell">
         <div className="streamThumbnail">
           <a href={`https://twitch.tv/${stream.name}`}>
-            <img src={this.getStreamThumbnail(stream.name)} alt={`${stream.name}'s thumbnail`} />
+            <img
+              src={this.getStreamThumbnail(stream.name)}
+              alt={`${stream.name}'s thumbnail`}
+            />
           </a>
         </div>
 
@@ -53,7 +56,11 @@ export default class StreamCell extends Component {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <img src={this.getGameThumbnail(game.name)} className="gameThumbnail" alt={game.name} />
+            <img
+              src={this.getGameThumbnail(game.name)}
+              className="gameThumbnail"
+              alt={game.name}
+            />
           </a>
         </div>
 
@@ -63,7 +70,9 @@ export default class StreamCell extends Component {
           <span className="viewerCount">{stream.viewers} viewers</span>
         </div>
 
-        <span className="streamGame">{game ? ` playing ${game.name}` : ''}</span>
+        <span className="streamGame">
+          {game ? ` playing ${game.name}` : ""}
+        </span>
         <span className="streamTitle">{stream.title}</span>
       </div>
     );

--- a/src/client/Directory/StreamCell.js
+++ b/src/client/Directory/StreamCell.js
@@ -1,8 +1,8 @@
-import React, { Component } from "react";
-import Img from "react-image";
+import React, { Component } from 'react';
+import Img from 'react-image';
 // import './Directory.css';
-import "./StreamCell.css";
-import PropTypes from "prop-types";
+import './StreamCell.css';
+import PropTypes from 'prop-types';
 
 const StreamWidth = 230;
 const StreamAspectRatio = 1.75;
@@ -21,8 +21,8 @@ export default class StreamCell extends Component {
 
   getStreamThumbnail(name) {
     return this.getThumbnail(
-      "https://static-cdn.jtvnw.net/previews-ttv/live_user_",
-      ["scarra", "novagw2", "abootgaming"].includes(name) ? "afdafd" : name,
+      'https://static-cdn.jtvnw.net/previews-ttv/live_user_',
+      name,
       StreamWidth,
       StreamAspectRatio
     );
@@ -30,22 +30,25 @@ export default class StreamCell extends Component {
 
   getGameThumbnail(game) {
     return this.getThumbnail(
-      "https://static-cdn.jtvnw.net/ttv-boxart/",
-      ["Guild Wars 2", "RimWorld"].includes(game) ? "fasfda" : game,
+      'https://static-cdn.jtvnw.net/ttv-boxart/',
+      game,
       GameWidth,
       GameAspectRatio
     );
   }
 
   getMissingImage(type) {
-    let name, width, height;
+    let name;
+    let width;
+    let height;
 
-    if (type == "game") {
-      name = "boxart";
+    if (type == 'game') {
+      name = 'boxart';
       width = GameWidth;
       height = parseInt(GameWidth / GameAspectRatio, 10);
-    } else {
-      name = "preview";
+    }
+    else {
+      name = 'preview';
       width = StreamWidth;
       height = parseInt(StreamWidth / StreamAspectRatio, 10);
     }
@@ -62,10 +65,7 @@ export default class StreamCell extends Component {
           <a href={`https://twitch.tv/${stream.name}`}>
             <Img
               alt={`${stream.name}'s thumbnail`}
-              src={[
-                this.getStreamThumbnail(stream.name),
-                this.getMissingImage("stream")
-              ]}
+              src={[this.getStreamThumbnail(stream.name), this.getMissingImage('stream')]}
             />
           </a>
         </div>
@@ -77,10 +77,7 @@ export default class StreamCell extends Component {
             rel="noopener noreferrer"
           >
             <Img
-              src={[
-                this.getGameThumbnail(game.name),
-                this.getMissingImage("game")
-              ]}
+              src={[this.getGameThumbnail(game.name), this.getMissingImage('game')]}
               className="gameThumbnail"
               alt={game.name}
             />
@@ -93,9 +90,7 @@ export default class StreamCell extends Component {
           <span className="viewerCount">{stream.viewers} viewers</span>
         </div>
 
-        <span className="streamGame">
-          {game ? ` playing ${game.name}` : ""}
-        </span>
+        <span className="streamGame">{game ? ` playing ${game.name}` : ''}</span>
         <span className="streamTitle">{stream.title}</span>
       </div>
     );

--- a/src/client/Directory/StreamCell.js
+++ b/src/client/Directory/StreamCell.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import Img from "react-image";
 // import './Directory.css';
 import "./StreamCell.css";
 import PropTypes from "prop-types";
@@ -21,7 +22,7 @@ export default class StreamCell extends Component {
   getStreamThumbnail(name) {
     return this.getThumbnail(
       "https://static-cdn.jtvnw.net/previews-ttv/live_user_",
-      name,
+      ["scarra", "novagw2", "abootgaming"].includes(name) ? "afdafd" : name,
       StreamWidth,
       StreamAspectRatio
     );
@@ -30,10 +31,26 @@ export default class StreamCell extends Component {
   getGameThumbnail(game) {
     return this.getThumbnail(
       "https://static-cdn.jtvnw.net/ttv-boxart/",
-      game,
+      ["Guild Wars 2", "RimWorld"].includes(game) ? "fasfda" : game,
       GameWidth,
       GameAspectRatio
     );
+  }
+
+  getMissingImage(type) {
+    let name, width, height;
+
+    if (type == "game") {
+      name = "boxart";
+      width = GameWidth;
+      height = parseInt(GameWidth / GameAspectRatio, 10);
+    } else {
+      name = "preview";
+      width = StreamWidth;
+      height = parseInt(StreamWidth / StreamAspectRatio, 10);
+    }
+
+    return `https://static-cdn.jtvnw.net/ttv-static/404_${name}-${width}x${height}.jpg`;
   }
 
   render() {
@@ -43,9 +60,12 @@ export default class StreamCell extends Component {
       <div className="streamCell">
         <div className="streamThumbnail">
           <a href={`https://twitch.tv/${stream.name}`}>
-            <img
-              src={this.getStreamThumbnail(stream.name)}
+            <Img
               alt={`${stream.name}'s thumbnail`}
+              src={[
+                this.getStreamThumbnail(stream.name),
+                this.getMissingImage("stream")
+              ]}
             />
           </a>
         </div>
@@ -56,8 +76,11 @@ export default class StreamCell extends Component {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <img
-              src={this.getGameThumbnail(game.name)}
+            <Img
+              src={[
+                this.getGameThumbnail(game.name),
+                this.getMissingImage("game")
+              ]}
               className="gameThumbnail"
               alt={game.name}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5448,7 +5448,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5626,6 +5626,13 @@ react-dom@^16.8.5:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.5"
+
+react-image@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-image/-/react-image-2.1.1.tgz#325b3f9fe828347b6cc063a59bc8e27f1ca46b00"
+  integrity sha512-rUsmeLCOJlzy/LBW2s8JGC1VS0TSBUdLDCdTdU7u3AenHBQM0aTzL3gtLnOJaXpshFUAPZxaLrxgmD7d3qkUMA==
+  dependencies:
+    prop-types "15.7.2"
 
 react-input-autosize@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
Applies to both Stream and Game images. 
Placeholder spaces are added, so that there is no jumping during image loads.
Also added 404 images, in case the images fail to load for some reason. 

Resolves #78 and #77 